### PR TITLE
Fixed deployment API version

### DIFF
--- a/namespaces/inventory/k8s-manifest.yaml
+++ b/namespaces/inventory/k8s-manifest.yaml
@@ -50,7 +50,7 @@ spec:
   selector:
     app: mysql
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mysql


### PR DESCRIPTION
Fixes the "Deployment" API version from `extensions/v1beta1` to `apps/v1 `for the MySQL deployment.