### PR TITLE
Fix for missing deployment selector.

### DIFF
--- a/namespaces/inventory/k8s-manifest.yaml
+++ b/namespaces/inventory/k8s-manifest.yaml
@@ -62,6 +62,9 @@ metadata:
     heritage: "Helm"
 
 spec:
+  selector:
+    matchLabels:
+      app: mysql
   template:
     metadata:
       labels:


### PR DESCRIPTION
Should fix 
```KNV2010: unable to create resource: KNV2010: failed to create "apps/v1, Kind=Deployment", "inventory/mysql": Deployment.apps "mysql" is invalid: [spec.selector: Required value, spec.template.metadata.labels: Invalid value: map[string]string{"app":"mysql"}: `selector` does not match template `labels`]```